### PR TITLE
adding validate function to check if a verify_code is valid

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -207,6 +207,30 @@ var sendRequest = require('./sendRequest');
     });
   };
 
+  /** Validate a verify_code */
+  Verify.validate = function(options, callback) {
+      if (!options || typeof options !== 'object') {
+        throw new Error('Error calling Verify validate - no params object provided.');
+      } else if (!callback || typeof callback !== 'function') {
+        throw new Error('Error calling Verify validate - no callback function provided.');
+      } else if (!options.verifyCode) {
+        return callback('Error calling Verify validate - "verifyCode" not provided in the request params.');
+      }
+
+      console.log('rid ' + options.referenceId);
+      console.log('vc ' + options.verifyCode);
+
+      sendRequest.request({
+        method: 'GET',
+        resource: '/verify/' + options.referenceId,
+        qs: {
+          verify_code: options.verifyCode
+        }
+      }, function(err, data) {
+        return callback(err, data);
+      });
+  };
+
   /* NPM EXPORT */
 
   if (typeof module === 'object' && module.exports) {


### PR DESCRIPTION
Provided the ability to send a verify_code, with a reference_id and check the status.  This will inform the caller if the verify_code is valid or not.
