### PR TITLE
Update the endpoint baseUrl

### DIFF
--- a/lib/sendRequest.js
+++ b/lib/sendRequest.js
@@ -16,14 +16,13 @@ var queryString = require('query-string');
   /* PRIVATE VARIABLES */
 
   var params;
-  var baseUri = 'https://rest.telesign.com';
 
   /* PUBLIC FUNCTIONS */
 
   SendRequest.setup = function (setupParams) {
     params = setupParams;
     request = request.defaults({
-      baseUrl: 'https://rest.telesign.com/v' + setupParams.version
+      baseUrl: 'https://rest-ww.telesign.com/v' + setupParams.version
     });
     authorize.setup(setupParams);
   };


### PR DESCRIPTION
I'm in touch with the provider, currently they are supporting both subdomains `rest` and `rest-ww` but at certain point in the near future `rest` will be deprecated.

Thank you for the library !